### PR TITLE
Fix "retrieve" command.

### DIFF
--- a/semicolon
+++ b/semicolon
@@ -152,8 +152,8 @@ var execute = function () {
         callStack.push(pc);
         jump(arg);
         break;
-      case "retreive":
-        stack.push(heap[stack.pop()]);
+      case "retrieve":
+        stack.push(heap[stack.pop()] || 0);
         break;
       case "ret":
         callStack.pop();


### PR DESCRIPTION
1) Spelling.
2) The language cannot deal with nulls make sure it never gets one.